### PR TITLE
Fix potential "Error opening /proc/1098/mem. Are you root?"

### DIFF
--- a/process_linux.go
+++ b/process_linux.go
@@ -112,7 +112,7 @@ func (p *Process) read(addr uintptr, ptr interface{}) error {
 		Cap:  int(dataSize),
 	}))
 	copy(*buf, dataBuf)
-
+	mem.Close()
 	return nil
 }
 
@@ -143,6 +143,6 @@ func (p *Process) write(addr uintptr, ptr interface{}) error {
 	} else if err != nil {
 		return err
 	}
-
+	mem.Close()
 	return nil
 }


### PR DESCRIPTION
Unix systems have a limit of available opened files at the same time. We need to close the file at the end of the function to prevent from reaching that limit. Great package by the way. Really wanna see it in complete state but it looks like it's never going to happen. Thank you nonetheless for the most complete memory reader in Go.